### PR TITLE
check --help in main() before everything else

### DIFF
--- a/include/virgo.h
+++ b/include/virgo.h
@@ -48,6 +48,11 @@ typedef struct virgo_t virgo_t;
 /** Opaque context of a Virgo Config Instance. */
 typedef struct virgo_conf_t virgo_conf_t;
 
+/*
+ * Checks if --help is passed.
+ */
+VIRGO_API(int) virgo_argv_has_help(virgo_t *v);
+
 /**
  * Creates a Virgo context.
  */

--- a/lib/virgo.c
+++ b/lib/virgo.c
@@ -204,6 +204,11 @@ int main(int argc, char* argv[])
     return EXIT_FAILURE;
   }
 
+  if (1 == virgo_argv_has_help(v)) {
+    show_help();
+    return 0;
+  }
+
   /* Set Service Name */
   err = virgo_conf_service_name(v, "Rackspace Monitoring Agent");
   if (err) {

--- a/lib/virgo_init.c
+++ b/lib/virgo_init.c
@@ -137,10 +137,6 @@ virgo_init(virgo_t *v)
 {
   virgo_error_t* err;
 
-  if (virgo__argv_has_flag(v, "-h", "--help") == 1) {
-    return virgo_error_create(VIRGO_EHELPREQ, "--help was passed");
-  }
-
   if (virgo__argv_has_flag(v, "-v", "--version") == 1) {
     return virgo_error_create(VIRGO_EVERSIONREQ, "--version was passed");
   }

--- a/lib/virgo_util.c
+++ b/lib/virgo_util.c
@@ -67,3 +67,8 @@ virgo__argv_has_flag(virgo_t *v, const char *short_opt, const char *long_opt)
 
   return 0;
 }
+
+int
+virgo_argv_has_help(virgo_t *v) {
+  return virgo__argv_has_flag(v, "-h", "--help");
+}


### PR DESCRIPTION
this fixes the bug that when only --help is passed, the program exits without printing help message due to invalid bundle; now --help is checked in main() before everything else
