### PR TITLE
Fix log rotation (send the correct signal post rotation)

### DIFF
--- a/pkg/logrotate/script.in
+++ b/pkg/logrotate/script.in
@@ -7,6 +7,6 @@
     notifempty
     create 640 root adm
     postrotate
-      kill -USR1 `cat /var/run/$PKG_NAME.pid`
+      kill -HUP `cat /var/run/$PKG_NAME.pid`
     endscript
 }


### PR DESCRIPTION
I just noticed that agent logs on my server are empty.

It happens that we are sending a wrong signal to the agent after the log rotation (`SIGUSR1` instead of `SIGHUP`) which means agent doesn't re-open a new log file after the rotation and keeps writing to the old file.

Reference: https://github.com/racker/virgo-base/blob/master/lib/lua/virgo_init.lua#L465
