### PR TITLE
Tiny: Fix duplicate options and typo

### DIFF
--- a/pkg/debian/package.init
+++ b/pkg/debian/package.init
@@ -27,7 +27,7 @@ fi
 
 case "$1" in
 start)	log_daemon_msg "Starting $NAME" "$NAME"
-        start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --startas $DAEMON -- -D -p $PIDFILE -l $LOG --production --restart-sysv-on-upgrade $EXTRA_OPTS
+        start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --startas $DAEMON -D -l $LOG --production --restart-sysv-on-upgrade $EXTRA_OPTS
         log_end_msg $?
 	;;
 stop)	log_daemon_msg "Stopping $NAME" "$NAME"


### PR DESCRIPTION
According to this https://github.com/racker/virgo/blob/master/agents/monitoring/monitoring.c#L61, -p and --pidfile are duplicates. 
