### PR TITLE
Disable thin archives so gyp does not try to pass a T option to older gnu binutils "ar" utility

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -133,6 +133,11 @@
             'ldflags': [ '-lm' ],
           }],
         ],
+       'target_conditions': [
+          ['_type=="static_library"', {
+            'standalone_static_library': 1, # disable thin archive which needs binutils >= 2.19
+          }],
+       ],
       }],
       ['OS=="mac"', {
         'ldflags': [ '-pthread', '-Wl,-E' ],


### PR DESCRIPTION
The "ar" utility that produces static library archives does not support thin archives as the new version of gyp desires.

The older binutils on rhel55 and centos58 exhibit this error.

We are disabling this for all builds on unix-like platforms which makes the static library archiving work similarly to older versions of gyp.  Building on newer platforms may not be as fast as fully optimal but should be no slower than before upgrading gyp.
