### PR TITLE
fix(build): Allow for many invalid uname -p values

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -170,12 +170,7 @@ def host_arch():
     if sys.platform == "darwin":
         return 'ia32'
 
-    arch = uname('-p')
-
-    if arch == 'unknown':
-        arch = uname('-m')
-
-    return {
+    arches = {
         'arm': 'arm',
         'x86': 'ia32',
         'i386': 'ia32',
@@ -184,7 +179,15 @@ def host_arch():
         'i686': 'ia32',
         'x86_64': 'x64',
         'amd64': 'x64',
-    }.get(arch, arch)
+    }
+
+    arch = uname('-p')
+
+    if arches.has_key(arch):
+        return arches.get(arch, arch)
+    else:
+        arch = uname('-m')
+        return arches.get(arch, arch)
 
 
 def target_arch():


### PR DESCRIPTION
- Some machines, like gentoo, return long strings for uname -p that aren't useful to the builder. For example: 'AMD FX(tm)-8350 Eight-Core Processor'.
- Now we catch any situation where we don't get a valid identifier from uname -p and failback to uname -m.
