### PR TITLE
fix: Windows Installer (MSI) to use correct program directory on x64

### DIFF
--- a/pkg/windows/virgo.wxs
+++ b/pkg/windows/virgo.wxs
@@ -10,7 +10,8 @@
     <?define RepoDir = $(var.REPODIR) ?>
     <?define BundleName = $(var.BUNDLE_NAME) ?>
     <?define PkgName = $(var.PKG_NAME) ?>
-<!--    <?define ProductDir = $(var.PRODUCTDIR) ?> -->
+    <?define PFilesDir = $(var.PFILESDIR) ?>
+  <!--    <?define ProductDir = $(var.PRODUCTDIR) ?> -->
 <!--    <?define ProductDir='C:\data\virgo\Debug' ?> -->
     <?define SourceDir = $(var.RepoDir) ?>
     <Product Name="$(var.ProductName)" Id="*" UpgradeCode="826873C9-1A63-4A05-98F4-95D8D8EF3507" Language="1033" Codepage="1252" Version="$(var.ProductVersion)" Manufacturer="$(var.ProductAuthor)">
@@ -24,7 +25,7 @@
         <Media Id="1" Cabinet="$(var.ProductName)Installer.cab" EmbedCab="yes" />
 
         <Directory Id="TARGETDIR" Name="SourceDir">
-            <Directory Id="ProgramFilesFolder" Name="PFiles">
+            <Directory Id="$(var.PFilesDir)" Name="PFiles">
                 <Directory Id="RAXMONAGENT" Name="$(var.ProductShortName)">
                     <Component Id="ZipBundle" Guid="F40E81F0-1044-4BF7-A4E6-0F3B0995E074">
                         <File Id="zip"

--- a/virgo.gyp
+++ b/virgo.gyp
@@ -1,8 +1,4 @@
 {
-  'variables': {
-    'target_arch': 'ia32',
-  },
-
   'targets': [
     {
       'target_name': 'virgo',
@@ -115,6 +111,20 @@
 
   'conditions': [
     [ 'OS=="win"', {
+      'conditions': [
+        [ 'target_arch=="x64"', {
+          'variables': {
+            'PFILESDIR': 'ProgramFiles64Folder',
+            'CANDLE_ARCH': 'x64',
+          },
+        }],
+        [ 'target_arch=="ia32"', {
+          'variables': {
+            'PFILESDIR': 'ProgramFilesFolder',
+            'CANDLE_ARCH': 'x86',
+          },
+        }],
+      ],
       'targets': [
         {
           'target_name': 'virgo.msi',
@@ -143,7 +153,9 @@
               '-out',
               '<@(_outputs)',
               'pkg/windows/virgo.wxs',
+              '-arch', '<(CANDLE_ARCH)',
               '-dSHORT_DESCRIPTION=<(SHORT_DESCRIPTION)',
+              '-dPFILESDIR=<(PFILESDIR)',
               '-dSHORT_NAME=<(SHORT_NAME)',
               '-dPRODUCTDESCRIPTION=<(SHORT_DESCRIPTION)',
               '-dLONG_DESCRIPTION=<(LONG_DESCRIPTION)',


### PR DESCRIPTION
For an ia32 installer on a x64 host the program files should be
installed in "C:\Program Files (x86)" but for an x64 installer
on an x64 host program files should be "C:\Program Files".
