### PR TITLE
make sure /var/lib/rackspace-monitoring-agent is created

### DIFF
--- a/pkg/debian/postinst
+++ b/pkg/debian/postinst
@@ -1,6 +1,8 @@
 #!/bin/sh
 update-rc.d $PKG_NAME defaults 91 09
 
+mkdir -p /var/lib/rackspace-monitoring-agent
+
 case "$1" in
     configure)
          /etc/init.d/$PKG_NAME stop || :

--- a/pkg/rpm/spec.in
+++ b/pkg/rpm/spec.in
@@ -58,6 +58,8 @@ rm -rf $RPM_BUILD_ROOT
 # This adds the proper /etc/rc*.d links for the script
 /sbin/chkconfig --add $PKG_NAME
 
+mkdir -p /var/lib/rackspace-monitoring-agent
+
 # Restart agent on upgrade
 if [ "$1" = "2" ] ; then
     /sbin/service $PKG_NAME stop  >/dev/null 2>&1 || :


### PR DESCRIPTION
Make sure /var/lib/rackspace-monitoring-agent path is created for crash dumps.
