### PR TITLE
fix(signal): unref the signal handling

### DIFF
--- a/lib/lua/virgo_init.lua
+++ b/lib/lua/virgo_init.lua
@@ -256,6 +256,7 @@ process.on = function(self, _type, listener)
           self:emit(_type, number)
         end)
         signal:start(number)
+        signal:unref()
       end
     end
   end


### PR DESCRIPTION
- In the virgo-example-agent, the event loop was being held open on a simple
  `print('hello world')`
