### PR TITLE
fix crash dump

### DIFF
--- a/lib/lua/virgo_debugger.lua
+++ b/lib/lua/virgo_debugger.lua
@@ -679,8 +679,12 @@ _G.dump_lua = function()
   local lua_dump = {}
   lua_dump.stack = stack
   lua_dump.tb = debug.traceback("", 2)
-  virgo["config"]["monitoring_token"] = "******"
-  lua_dump.virgo = dump(virgo)
+  if virgo and virgo["config"] then
+    virgo["config"]["monitoring_token"] = "******"
+    lua_dump.virgo = dump(virgo)
+  else
+    lua_dump.virgo = dump({})
+  end
   lua_dump.globals = dump(getfenv(0))
   return JSON.stringify(lua_dump)
 end

--- a/lib/virgo_crash_reporter.cc
+++ b/lib/virgo_crash_reporter.cc
@@ -57,12 +57,12 @@ static bool dumpCallback(const char* dump_path, const char* minidump_id, void* c
   fprintf(fp, "%s\n%s", DEMARCATOR, VERSION_FULL);
 
   L = v->L;
-
   if (!L){
     printf("No lua found.");
     fclose(fp);
     return succeeded;
   }
+
   lua_getglobal(L, "dump_lua");
   rv = lua_pcall(L, 0, 1, 0);
   if (rv != 0) {


### PR DESCRIPTION
crash dumper was indexing the `virgo` table which may or may not exist depending on when the crash executes.
