### PR TITLE
Use the DEFINE as opposed to a hard coded value

### DIFF
--- a/lib/virgo_logging.c
+++ b/lib/virgo_logging.c
@@ -158,7 +158,7 @@ virgo_log(virgo_t *v, virgo_log_level_e level, const char *str)
     memcpy(&buf[0]+blen, llstr, 6);
     blen += 6;
 
-    availlen = sizeof(buf) - blen - 2;
+    availlen = sizeof(buf) - blen - EOL_LEN;
 
     if (slen > availlen) {
       slen = availlen;


### PR DESCRIPTION
Fixes a buffer overflow in the log strings
