### PR TITLE
Fix: pass features as an array of tables

### DIFF
--- a/libs/connection.lua
+++ b/libs/connection.lua
@@ -272,7 +272,7 @@ function Connection:_handshakeMessage()
       agent_name = self.options.agent.name,
       process_version = virgo.virgo_version,
       bundle_version = virgo.bundle_version,
-      features = table.concat(self.features or {}, ',') ,
+      features = self.features or {},
     },
   }
 end

--- a/protocol/messages.lua
+++ b/protocol/messages.lua
@@ -93,7 +93,7 @@ function HandshakeHello:initialize(token, agentId, features)
   self.params.agent_name = virgo.pkg_name
   self.params.process_version = virgo.virgo_version
   self.params.bundle_version = virgo.bundle_version
-  self.params.features = table.concat(features or {}, ',')
+  self.params.features = features
 end
 
 --[[ Heartbeat ]]--


### PR DESCRIPTION
[
  { name: "foo", version: "1.2.3" },
  { name: "bar", version: "4.5.6" }
]
