### PR TITLE
Fix: add extensions to the handshake.hello

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -59,6 +59,7 @@ function AgentClient:initialize(options, connectionStream, types)
   self._host = options.host
   self._proxy = options.proxy
   self._features = options.features
+  self._extensions = options.extensions
 
   self._timeout = options.timeout or 5000
 
@@ -132,6 +133,7 @@ function AgentClient:connect()
   options.agent.name = virgo.pkg_name
   options.proxy = self._proxy
   options.features = self._features
+  options.extensions = self._extensions
 
   self._connection = Connection:new({}, options)
   self._log(logging.DEBUG, 'Connecting...')

--- a/libs/connection.lua
+++ b/libs/connection.lua
@@ -49,6 +49,7 @@ function Connection:initialize(manifest, options)
   self.options = options or {}
   self.proxy = self.options.proxy
   self.features = options.features or {}
+  self.extensions = options.extensions or {}
 
   self.timers = {}
 
@@ -256,6 +257,7 @@ function Connection:_handshake()
       self:_error(string.format("Handshake timeout, haven't received response in %d ms", HANDSHAKE_TIMEOUT))
     end
   end))
+  self._log(logging.DEBUG, fmt('SENDING: (%s) => %s', 'unknown', JSON.stringify(msg)))
   self.writable:write(msg)
 end
 
@@ -273,6 +275,7 @@ function Connection:_handshakeMessage()
       process_version = virgo.virgo_version,
       bundle_version = virgo.bundle_version,
       features = self.features or {},
+      extensions = self.extensions['handshake.hello'] or {}
     },
   }
 end


### PR DESCRIPTION
This adds a concept of message extensions that can contain semi-opaque data.  An "options" hash is passed down through the agent many places but in each case we crack it open and take what we need and then pass a subset down to the next layer.  The extensions idea is to get passed down through all the layers and each layer or message uses what it needs.

This is an use case for the handshake message getting additional data from the application built on to the base-agent.
