### PR TITLE
Fix: VERSION_FULL alread has VERSION_RELEASE included

### DIFF
--- a/lib/virgo.c
+++ b/lib/virgo.c
@@ -92,7 +92,7 @@ service_maintenance(virgo_t *v)
 static void
 show_version(virgo_t *v)
 {
-  printf("%s-%s", VERSION_FULL, VERSION_RELEASE);
+  printf("%s", VERSION_FULL);
   fflush(stdout);
 }
 


### PR DESCRIPTION
see https://github.com/virgo-agent-toolkit/virgo-base-agent/pull/116
