### PR TITLE
make sure pointer value is non nil

### DIFF
--- a/lib/virgo_conf.c
+++ b/lib/virgo_conf.c
@@ -197,11 +197,11 @@ conf_parse(virgo_t *v, FILE *fp)
     /* calculate key/value pairs */
     key = next_chunk(&p);
     p = key;
-    while(!isspace(p[0])) { p++;};
+    while(*p && !isspace(*p)) { p++;};
     *p = '\0'; /* null terminate key */
     node->key = strdup(key);
     p++;
-    while(isspace(p[0])) { p++;};
+    while(*p && isspace(*p)) { p++;};
     node->value = strdup(p);
 
     free(key);


### PR DESCRIPTION
```
#0  0x000000000045799c in conf_parse (v=0x12d7940, fp=0x12e9de0) at ../base/lib/virgo_conf.c:200
200	../base/lib/virgo_conf.c: No such file or directory.
(gdb) bt
#0  0x000000000045799c in conf_parse (v=0x12d7940, fp=0x12e9de0) at ../base/lib/virgo_conf.c:200
#1  0x0000000000457b15 in virgo__conf_init (v=0x12d7940) at ../base/lib/virgo_conf.c:319
#2  0x00000000004580e4 in virgo_run (v=0x12d7940) at ../base/lib/virgo_init.c:167
#3  0x00000000004573a8 in main_wrapper (v=0x12d7940) at ../base/lib/virgo.c:176
#4  0x00000000004574fd in main (argc=<optimized out>, argv=<optimized out>) at ../base/lib/virgo.c:198
(gdb) q
```