### PR TITLE
R4R: systemd debian + fedora fixes

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -142,6 +142,7 @@ def configure_pkg(platform, pkg_vars):
         open(os.path.join(out_dir, 'changelog'), 'wb').write(log.encode('utf8'))
         render('../include.mk.in', 'include.mk')
         render('../logrotate/script.in', 'script')
+        render('../systemd/agent.service', '%s.service' % name)
     elif mapping['PKG_TYPE'] == 'rpm':
         render('rpm/spec.in', '%s.spec' % name)
         render('logrotate/script.in', 'script')

--- a/pkg/debian/postinst
+++ b/pkg/debian/postinst
@@ -1,23 +1,41 @@
 #!/bin/sh
-update-rc.d $PKG_NAME defaults 91 09
+
+if [ -f /etc/init.d/$PKG_NAME ] ; then
+  update-rc.d $PKG_NAME defaults 91 09
+fi
 
 mkdir -p /var/lib/$PKG_NAME
 mkdir -p /etc/$PKG_NAME.conf.d
 
+legacy_start() {
+  /etc/init.d/$PKG_NAME stop || :
+
+  # Cleanup init's mess if it fails to stop
+  PIDFILE=/var/run/$PKG_NAME.pid
+  start-stop-daemon --stop --retry 5 --quiet --pidfile $PIDFILE --name rackspace-monit --signal KILL
+
+  # Start only if we find a config file in place
+  if [ -f /etc/$PKG_NAME.cfg ]; then
+    /etc/init.d/$PKG_NAME start || :
+  fi
+
+  exit $?
+}
+
 case "$1" in
     configure)
-         /etc/init.d/$PKG_NAME stop || :
-
-         # Cleanup init's mess if it fails to stop
-         PIDFILE=/var/run/$PKG_NAME.pid
-         start-stop-daemon --stop --retry 5 --quiet --pidfile $PIDFILE --name rackspace-monit --signal KILL
-
-         # Start only if we find a config file in place
-         if [ -f /etc/$PKG_NAME.cfg ]; then
-              /etc/init.d/$PKG_NAME start || :
-         fi
-        ;;
+      if [ -x "/etc/init.d/$PKG_NAME" ] || [ -e "/etc/init/$PKG_NAME.conf" ]; then
+        legacy_start
+      fi
+      if [ -x "/bin/systemctl"  ]; then
+        /bin/systemctl reload $PKG_NAME.service >/dev/null 2>&1 || true
+        /bin/systemctl enable $PKG_NAME.service >/dev/null 2>&1 || true
+        if [ -f "/etc/rackspace-monitoring-agent.cfg" ] ; then
+          /bin/systemctl restart $PKG_NAME.service >/dev/null 2>&1 || true
+        fi
+      fi
+      ;;
     *)
-        echo "Unrecognized postinst argument '$1'"
-        ;;
+      echo "Unrecognized postinst argument '$1'"
+      ;;
 esac

--- a/pkg/debian/rules
+++ b/pkg/debian/rules
@@ -8,6 +8,7 @@ SHAREDIR=$(DESTDIR)/usr/share/$(NAME)
 INITDIR=$(DESTDIR)/etc/init
 INITDDIR=$(DESTDIR)/etc/init.d
 LOGROTATEDDIR=$(DESTDIR)/etc/logrotate.d
+SYSTEMDDIR=$(DESTDIR)/lib/systemd/system
 
 clean:
 	dh_testdir
@@ -34,6 +35,8 @@ install: build
 	install -o root -g root -m 755 debian/package.init $(INITDDIR)/$(NAME)
 	install -d $(LOGROTATEDDIR)
 	install -o root -g root -m 644 $(CURDIR)/base/pkg/out/script $(LOGROTATEDDIR)/$(NAME)
+	install -d $(SYSTEMDDIR)
+	install -o root -g root -m 644 $(CURDIR)/base/pkg/out/$(NAME).service $(SYSTEMDDIR)/$(NAME).service
 
 binary-arch: build install
 	dh_testdir

--- a/pkg/rpm/spec.in
+++ b/pkg/rpm/spec.in
@@ -64,8 +64,16 @@ mkdir -p /var/lib/rackspace-monitoring-agent
 
 # Restart agent on upgrade
 if [ "$1" = "2" ] ; then
-    /sbin/service $PKG_NAME stop  >/dev/null 2>&1 || :
-    /sbin/service $PKG_NAME start >/dev/null 2>&1 || :
+    if [ -x "/bin/systemctl" ] ; then
+      /bin/systemctl reload $PKG_NAME.service >/dev/null 2>&1 || true
+      /bin/systemctl enable $PKG_NAME.service >/dev/null 2>&1 || true
+      if [ -f "/etc/rackspace-monitoring-agent.cfg" ] ; then
+        /bin/systemctl restart $PKG_NAME.service >/dev/null 2>&1 || true
+      fi
+    else
+      /sbin/service $PKG_NAME stop  >/dev/null 2>&1 || :
+      /sbin/service $PKG_NAME start >/dev/null 2>&1 || :
+    fi
 fi
 
 %preun

--- a/pkg/systemd/agent.service
+++ b/pkg/systemd/agent.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=$SHORT_DESCRIPTION
 Documentation=$DOCUMENTATION_LINK
-After=network.target
+After=network-online.target
 
 [Service]
 ExecStart=/usr/bin/$PKG_NAME -l /var/log/$PKG_NAME.log --production --exit-on-upgrade


### PR DESCRIPTION
* Adds systemd support for Ubuntu 15.04
* Makes sure the agent comes online after the networking is online ``` network-online.target ```
* On Fedora machines make sure systemctl is registering the service