### PR TITLE
Catch invalid socket timeout computation from invalid handshake response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 deps
 virgo
 luvi
+luvit
+luvi-sigar
 lit*
+/.idea/
+/*.iml

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 APP_FILES=$(shell find . tests -type f)
-LIT_VERSION=3.3.3
+LIT_VERSION=3.5.4
 
 all: luvi-sigar $(APP_FILES)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,5 +13,3 @@ test_script:
     - Make.bat test
 
 notifications:
-    email: true
-    irc: "irc.freenode.org#virgo"

--- a/client/client.lua
+++ b/client/client.lua
@@ -148,6 +148,12 @@ function AgentClient:connect()
       self._heartbeat_interval = self._connection.handshake_msg.result.heartbeat_interval
       self._entity_id = self._connection.handshake_msg.result.entity_id
       self._connectionStream:setChannel(self._connection.handshake_msg.result.channel)
+
+      local socket_timeout = self:_socketTimeout()
+      self._log(logging.DEBUG, fmt('Using timeout %sms', socket_timeout))
+      self._connection:setTimeout(socket_timeout, function()
+        self:emit('timeout')
+      end)
     end)
     if err then
       if self._connection.handshake_msg then
@@ -159,11 +165,6 @@ function AgentClient:connect()
       self:emit('handshake_success', self._connection.handshake_msg.result)
     end
 
-    local socket_timeout = self:_socketTimeout()
-    self._log(logging.DEBUG, fmt('Using timeout %sms', socket_timeout))
-    self._connection:setTimeout(socket_timeout, function()
-      self:emit('timeout')
-    end)
     self._connection:getSocket():on('end', function()
       self:emit('end')
     end)

--- a/package.lua
+++ b/package.lua
@@ -1,6 +1,6 @@
 return {
   name = "virgo-agent-toolkit/virgo",
-  version = "2.1.6",
+  version = "2.1.7",
   luvi = {
     version = "2.7.2-sigar",
     flavor = "sigar",

--- a/protocol/connection.lua
+++ b/protocol/connection.lua
@@ -205,7 +205,6 @@ function AgentProtocolConnection:_send(msg, callback, timeout)
           if err.code == 400 then
             self._log(logging.ERROR, fmt('Non-fatal error: %s', err.message))
           else
-            self._log(logging.ERROR, fmt('Fatal error: %s: %s', err.type, err.message))
             self:emit('error', err)
           end
         end

--- a/protocol/connection.lua
+++ b/protocol/connection.lua
@@ -205,6 +205,7 @@ function AgentProtocolConnection:_send(msg, callback, timeout)
           if err.code == 400 then
             self._log(logging.ERROR, fmt('Non-fatal error: %s', err.message))
           else
+            self._log(logging.ERROR, fmt('Fatal error: %s: %s', err.type, err.message))
             self:emit('error', err)
           end
         end


### PR DESCRIPTION
Fixes this stacktrace observed in syslog:

```
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: Uncaught Error: [string "bundle:deps/virgo/client/client.lua"]:101: attempt to perform arithmetic on field '_heartbeat_interval' (a nil value)
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: stack traceback:
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/virgo/client/client.lua"]:101: in function '_socketTimeout'
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/virgo/client/client.lua"]:162: in function 'handler'
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/core.lua"]:248: in function 'emit'
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/virgo/connection.lua"]:115: in function '_changeState'
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/virgo/connection.lua"]:254: in function 'handler'
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/core.lua"]:248: in function 'emit'
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/stream/stream_readable.lua"]:172: in function 'push'
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/split-stream/lib/split.lua"]:41: in function '_transform'
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/stream/stream_transform.lua"]:197: in function '_read'
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/stream/stream_transform.lua"]:182: in function '_write'
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011...
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/stream/stream_readable.lua"]:556: in function 'handler'
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/core.lua"]:248: in function 'emit'
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/stream/stream_readable.lua"]:172: in function 'push'
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/tls/common.lua"]:336: in function 'incoming'
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/tls/common.lua"]:349: in function <[string "bundle:deps/tls/common.lua"]:341>
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[C]: in function 'run'
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/luvit/init.lua"]:52: in function <[string "bundle:deps/luvit/init.lua"]:47>
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[C]: in function 'xpcall'
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/luvit/init.lua"]:47: in function 'fn'
Oct  5 19:29:04 860321-infra01 rackspace-monitoring-agent[230653]: #011[string "bundle:deps/require.lua"]:310: in function <[string "bundle:deps/require.lua"]:266>
```