### PR TITLE
Bump to 2.1.9

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+## virgo-base-agent 2.1.9
+
+ * Upgrade luvit to 2.15.0 for connection handling improvements
+
 ## virgo-base-agent 2.1.8
 
  * Add critical log when all endpoint connections are lost and change existing connection errors to warning

--- a/package.lua
+++ b/package.lua
@@ -1,6 +1,6 @@
 return {
   name = "virgo-agent-toolkit/virgo",
-  version = "2.1.8",
+  version = "2.1.9",
   luvi = {
     version = "2.7.2-sigar",
     flavor = "sigar",


### PR DESCRIPTION
Need to do a new release to pull in luvit 2.15.0.

It will automatically get pulled in by the existing package config: `"luvit/luvit@2"`

```
# Changes in 2.15.0

 - examples: Fix http-download.lua statusCode (#1010) [eZethNesthrown]
 - http: Fix http-codec not reading full header when header has no value (#1021) [Ryan Liptak]
 - http: Fix parse HTTP status lines (#1039) [George Zhao]
 - https: Fix bug EAI_NONAME in tls.connect (#1039) [George Zhao]
 - init: Flush stream on exit (#1007) [Tim Caswell]
 - net: Fix ignored connect errors (#1031) [Ernest Climent]
 - net: Fix ignored getaddrinfo errors (#1032) [Ernest Climent]
 - net: Remove keepalive on listening socket (#1028) [George Zhao]
 - process: Add process:cpuUsage() and process:memoryUsage() (#1014) [Ryan Liptak]
 - querystring: Fix bug in update urlencoding (#1040) [George Zhao]
 - repl: Add simple error handling to REPL autocomplete (#1038) [aiverson]
 - stream: Fix Stream.Readable.unpipe when piped to multiple streams (#1020) [Ryan Liptak]
 - timer: Fix timer sleep (#1001) [SinisterRectus]
- tls: Update default TLS from TLSv1 to TLSv1.2 (#1041) [George Zhao]
```