### PR TITLE
Add a timeout to proxy connections

### DIFF
--- a/util/constants_ctx.lua
+++ b/util/constants_ctx.lua
@@ -72,6 +72,9 @@ globalCtx:set('DATACENTER_FIRST_RECONNECT_DELAY_JITTER', 37 * 1000) -- initial d
 globalCtx:set('DATACENTER_RECONNECT_DELAY', 2 * 60 * 1000) -- max connection delay
 globalCtx:set('DATACENTER_RECONNECT_DELAY_JITTER', 17 * 1000)
 
+globalCtx:set('PROXY_TIMEOUT', 2 * 24 * 60 * 60 * 1000) -- 2 days
+globalCtx:set('PROXY_TIMEOUT_JITTER', 1 * 24 * 60 * 60 * 1000) -- 1 day
+
 globalCtx:set('SRV_RECORD_FAILURE_DELAY', 13 * 1000)
 globalCtx:set('SRV_RECORD_FAILURE_DELAY_JITTER', 37 * 1000)
 


### PR DESCRIPTION
This is simply a workaround to a problem.  It is not a perfect solution.

We have seen issues with agents using the proxy feature where they will disconnect from the endpoints but do not try to reconnect again.  They end up hanging at the `PROXIED` state.

We have been unable to reproduce it and the cases where it has been seen are inside customer environments where we cannot dig around for more details.

This "solution" will ensure proxy connections are rebuilt every 2-3 days to ensure they cannot stay down forever while the agent is actually still running.

As there are typically 3 separate connections for each agent this timeframe should be good enough as we have not seen all connections drop off at the same time; the disconnections have been spread over a longer period of time.

One of the bad things with this change is that every time the connection times out it will log an error message.  However, as this change will affect so few people it seems worth it for now until the real problem can be found.